### PR TITLE
이메일 유효성 검사 로직 개선

### DIFF
--- a/src/_utils/validateEmail.ts
+++ b/src/_utils/validateEmail.ts
@@ -1,8 +1,21 @@
 export const validateEmail = (email: string): boolean => {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  const koreanRegex = /[ㄱ-ㅎㅏ-ㅣ가-힣]/;
+  const emailRegex =
+    /^[a-zA-Z0-9][a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*[a-zA-Z0-9]@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
-  return email.trim() !== '' && emailRegex.test(email) && !koreanRegex.test(email);
+  const invalidCharsRegex =
+    /[ㄱ-ㅎㅏ-ㅣ가-힣\u{1F600}-\u{1F64F}\u{2600}-\u{26FF}]/u;
+
+  const consecutiveSpecialCharsRegex = /[!#$%&'*+/=?^_`{|}~-]{2,}/;
+
+  const trimmedEmail = email.trim().toLowerCase();
+
+  if (trimmedEmail === "") return false;
+  if (trimmedEmail.length > 254) return false;
+  if (invalidCharsRegex.test(trimmedEmail)) return false;
+  if (trimmedEmail.includes("..")) return false;
+  if (consecutiveSpecialCharsRegex.test(trimmedEmail)) return false;
+
+  return emailRegex.test(trimmedEmail);
 };
 
 export default validateEmail;


### PR DESCRIPTION


## 간략한 설명
#96 
안녕하세요! 현재 이메일 유효성 검사 로직에 대해 몇 가지 개선점을 제안드리고 싶습니다.

## 수정된 내용
 - 연속된 점(.) 사용 불가
 - 이메일 주소가 점(.)으로 시작할 수 없음
 - 이모지 및 유니코드 문자 사용 제한
 - 최대 길이 제한 (254자)
 - 연속된 특수문자 사용 제한


## 테스트 케이스
기존에 아래와 같은 케이스들이 통과되어 수정했습니다.
```
test@test..com
.test@domain.com
test😎@domain.com
매우 긴 이메일 주소
test##@domain.com
```
