### PR TITLE
마크다운 프리뷰 table 깨짐 현상 (issue #90)

### DIFF
--- a/src/app/globals.css.ts
+++ b/src/app/globals.css.ts
@@ -51,7 +51,6 @@ globalStyle("ul", {
   padding: "0",
 });
 
-
 globalStyle(`:root`, {
   background: lightTheme.colorBackground,
 });
@@ -120,3 +119,10 @@ globalStyle(
     color: "#246398 !important",
   }
 );
+
+// 테이블표
+
+globalStyle(".wmde-markdown table tr", {
+  color: `${text1} !important`,
+  background: `none !important`,
+});


### PR DESCRIPTION
1. 스타일링을 수정했습니다.
<img width="960" alt="스크린샷 2024-11-01 오전 11 27 39" src="https://github.com/user-attachments/assets/ccd8d92e-0183-4473-a170-caafdda74c41">

2. 테이블 자체가 overflow 되는 부분을 수정했습니다.

<img width="436" alt="스크린샷 2024-11-01 오전 11 54 09" src="https://github.com/user-attachments/assets/b4eec3f1-ddf9-452e-8d6e-8367f01663e9">

