### PR TITLE
QA 사항 반영 (issue #115)

### DIFF
--- a/src/_components/Home/SubscribeModal/SubscribeModalContent.tsx
+++ b/src/_components/Home/SubscribeModal/SubscribeModalContent.tsx
@@ -105,6 +105,7 @@ export default function SubscribeModalContent({ closeModal }: SubscribeModalCont
                     isError={isSubscriptionError}
                     maxLength={4}
                     type="text"
+                    inputMode="numeric"
                   />
 
                   <CheckboxInput

--- a/src/_components/Home/SubscribeModal/VerifyEmailInput.tsx
+++ b/src/_components/Home/SubscribeModal/VerifyEmailInput.tsx
@@ -49,7 +49,9 @@ export default function VerifyEmailInput({
 
       <Button
         variant="primary"
-        disabled={!email || isVerifyingPending || !isValidEmail || !isValidCategories}
+        disabled={
+          !email || isVerifyingPending || !isValidEmail || !isValidCategories
+        }
         onClick={handleVerifyEmail}
       >
         확인

--- a/src/_components/common/Modal/ScrollPreventer.tsx
+++ b/src/_components/common/Modal/ScrollPreventer.tsx
@@ -1,21 +1,31 @@
-import { useEffect } from 'react';
-import type { PropsWithChildren } from 'react';
-import { noScroll } from './scrollPreventer.css';
+import { useEffect } from "react";
+import type { PropsWithChildren } from "react";
+import { noScroll } from "./scrollPreventer.css";
 
 interface PreventScrollObserverProps extends PropsWithChildren {
   isOpen?: boolean;
 }
 
-export default function ScrollPreventer({ isOpen = true, children }: PreventScrollObserverProps) {
+export default function ScrollPreventer({
+  isOpen = true,
+  children,
+}: PreventScrollObserverProps) {
   useEffect(() => {
+    const preventTouchMove = (event: TouchEvent) => event.preventDefault();
+
     if (isOpen) {
       document.body.classList.add(noScroll);
+      document.addEventListener("touchmove", preventTouchMove, {
+        passive: false,
+      });
     } else {
       document.body.classList.remove(noScroll);
+      document.removeEventListener("touchmove", preventTouchMove);
     }
 
     return () => {
       document.body.classList.remove(noScroll);
+      document.removeEventListener("touchmove", preventTouchMove);
     };
   }, [isOpen]);
 

--- a/src/_components/common/Modal/scrollPreventer.css.ts
+++ b/src/_components/common/Modal/scrollPreventer.css.ts
@@ -1,6 +1,7 @@
-import { style } from '@vanilla-extract/css';
+import { style } from "@vanilla-extract/css";
 
 export const noScroll = style({
-  overflow: 'hidden',
-  height: '100%',
+  overflow: "hidden",
+  height: "100%",
+  touchAction: "none",
 });


### PR DESCRIPTION
- [x] 인풋을 포커스하여 키보드를 띄우면, 모달 스크롤이 가능해지는 현상

모바일 환경에서는 기본적으로 인풋에 포커싱이 되면 스크롤 제약사항을 무시한다고 하네요! 
기존에 작성해놨던 `ScrollPreventer`컴포넌트에서 `touchmove`이벤트를 추가하여 기본 동작을 막아주도록 하였습니다.

https://github.com/user-attachments/assets/fdfbf1e2-2aa7-452e-a24e-25d20147213c

=> 인풋 관련 키보드가 나오더라도 모달 스크롤이 적용 되지 않습니다.
