### PR TITLE
fix(APIClient): delete 메서드 내 json 반환 로직 삭제

### DIFF
--- a/src/_apis/client/APIClient.ts
+++ b/src/_apis/client/APIClient.ts
@@ -39,11 +39,8 @@ export default class APIClient {
     return data as T;
   }
 
-  async delete<T = any>(path: string, body?: any): Promise<T> {
-    const res = await this.request<T>('DELETE', path, body);
-    const data = await res.json();
-
-    return data as T;
+  async delete<T = any>(path: string, body?: any): Promise<void> {
+    await this.request<T>('DELETE', path, body);
   }
 
   async request<T>(method: HTTPMethod, path: string, body?: any): Promise<Response> {

--- a/src/_components/Unsubscribe/UnsubscribeContent.tsx
+++ b/src/_components/Unsubscribe/UnsubscribeContent.tsx
@@ -20,8 +20,10 @@ export default function UnsubscribeContent({ email, token }: UnsubscribeContentP
   const { push } = useRouter();
 
   const handleUnsubscribe = async () => {
-    await deleteSubscribe({ email, token });
-    push(PAGE_ROUTES.unsubscribeCompleted);
+    if (confirm('구독을 해지하시겠습니까?')) {
+      await deleteSubscribe({ email, token });
+      push(PAGE_ROUTES.unsubscribeCompleted);
+    }
   };
 
   return (


### PR DESCRIPTION
### 작업 내용

- APIClient delete 메서드 내 json 반환 로직 삭제합니다.
- 구독 해지 시의 confirm을 추가합니다.

### 연관 이슈

- close #188