### PR TITLE
design(global.css): 코드 블록 텍스트 및 배경 색상 수정

### DIFF
--- a/src/app/globals.css.ts
+++ b/src/app/globals.css.ts
@@ -79,6 +79,8 @@ globalStyle('.wmde-markdown h2', {
 globalStyle('.wmde-markdown code', {
   fontSize: '1.3rem !important',
   padding: '0.2em 0.2em',
+  backgroundColor: '#F5F8FA !important',
+  color: '#eb5757',
 });
 
 globalStyle('.wmde-markdown pre', {
@@ -142,4 +144,5 @@ globalStyle('.wmde-markdown table td', {
 
 globalStyle('.wmde-markdown .code-highlight', {
   background: '#F5F8FA',
+  color: '#222222 !important',
 });


### PR DESCRIPTION
### 작업 내용
<img width="1157" alt="스크린샷 2025-03-09 오후 3 41 08" src="https://github.com/user-attachments/assets/3a7a8e8e-8caf-4a2c-af92-b1317c03dc10" />


단문 코드 블록 마크다운의 가독성이 좋지 않다는 유저 피드백에 따라, 텍스트 색상을 `#EB5757`로, 배경 색상을 `#F5F8FA`로 수정합니다.

### 연관 이슈

- close #221
