### PR TITLE
[Refactor] API response type 선언

### DIFF
--- a/apps/maeilmail/src/common/types/question.ts
+++ b/apps/maeilmail/src/common/types/question.ts
@@ -9,3 +9,14 @@ export interface Question {
   content: string;
   category: QuestionCategoryEN;
 }
+
+export interface QuestionDetail extends Question {
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MyQuestion {
+  id: number;
+  title: string;
+  category: 'frontend' | 'backend';
+}

--- a/apps/maeilmail/src/common/types/question.ts
+++ b/apps/maeilmail/src/common/types/question.ts
@@ -2,6 +2,7 @@ import type { QUESTION_CATEGORY } from '../constants/questionCategory';
 
 export type QuestionCategoryKO = keyof typeof QUESTION_CATEGORY;
 export type QuestionCategoryEN = (typeof QUESTION_CATEGORY)[QuestionCategoryKO];
+export type QuestionCategoryENWithOutAll = Exclude<QuestionCategoryEN, 'all'>;
 
 export interface Question {
   id: number;
@@ -18,5 +19,5 @@ export interface QuestionDetail extends Question {
 export interface MyQuestion {
   id: number;
   title: string;
-  category: 'frontend' | 'backend';
+  category: QuestionCategoryENWithOutAll;
 }

--- a/apps/maeilmail/src/components/myQuestionList/QuestionItem.tsx
+++ b/apps/maeilmail/src/components/myQuestionList/QuestionItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { MyQuestion } from './QuestionList';
+import { MyQuestion } from '@/common/types/question';
 import RightArrow from '@/assets/icons/rightArrow.svg';
 import {
   animatedHover,

--- a/apps/maeilmail/src/components/myQuestionList/QuestionList.tsx
+++ b/apps/maeilmail/src/components/myQuestionList/QuestionList.tsx
@@ -4,12 +4,7 @@ import * as React from 'react';
 import MyQuestionItem from './QuestionItem';
 import { emptyCase, questionListContainer } from './questionList.css';
 import Link from 'next/link';
-
-export interface MyQuestion {
-  id: number;
-  category: 'frontend' | 'backend';
-  title: string;
-}
+import { MyQuestion } from '@/common/types/question';
 
 export interface QuestionListProps {
   questions: MyQuestion[];

--- a/apps/maeilmail/src/components/myQuestionList/apis/getMyQuestions.ts
+++ b/apps/maeilmail/src/components/myQuestionList/apis/getMyQuestions.ts
@@ -2,7 +2,7 @@ import mainClient from '@/common/apis/client/mainClient';
 import { pathGenerator } from '@/common/apis/constants/routes';
 import { MyQuestion, QuestionCategoryEN } from '@/common/types/question';
 
-interface MyQuestionsResponse {
+interface GetMyQuestionsResponse {
   totalPage: number;
   isLastPage: boolean;
   data: MyQuestion[];
@@ -14,7 +14,7 @@ export const getMyQuestions = async (
   page: number = 1,
   category: QuestionCategoryEN,
 ) => {
-  const data = await mainClient.get<MyQuestionsResponse>(
+  const data = await mainClient.get<GetMyQuestionsResponse>(
     pathGenerator.myQuestions(email, page - 1, category),
   );
 

--- a/apps/maeilmail/src/components/myQuestionList/apis/getMyQuestions.ts
+++ b/apps/maeilmail/src/components/myQuestionList/apis/getMyQuestions.ts
@@ -1,6 +1,12 @@
 import mainClient from '@/common/apis/client/mainClient';
 import { pathGenerator } from '@/common/apis/constants/routes';
-import { QuestionCategoryEN } from '@/common/types/question';
+import { MyQuestion, QuestionCategoryEN } from '@/common/types/question';
+
+interface MyQuestionsResponse {
+  totalPage: number;
+  isLastPage: boolean;
+  data: MyQuestion[];
+}
 
 // page 변수는 frontend에서 1 base, backend에서 0 base입니다.
 export const getMyQuestions = async (
@@ -8,7 +14,9 @@ export const getMyQuestions = async (
   page: number = 1,
   category: QuestionCategoryEN,
 ) => {
-  const data = await mainClient.get(pathGenerator.myQuestions(email, page - 1, category));
+  const data = await mainClient.get<MyQuestionsResponse>(
+    pathGenerator.myQuestions(email, page - 1, category),
+  );
 
   return data;
 };

--- a/apps/maeilmail/src/components/questionDetail/DetailCategory.tsx
+++ b/apps/maeilmail/src/components/questionDetail/DetailCategory.tsx
@@ -1,8 +1,8 @@
 import { textWrapper, categoryHighlight } from './questionDetail.css';
-import { QuestionCategoryEN } from '@/common/types/question';
+import { QuestionCategoryENWithOutAll } from '@/common/types/question';
 
 interface DetailCategoryProps {
-  category: QuestionCategoryEN;
+  category: QuestionCategoryENWithOutAll;
 }
 
 export default function DetailCategory({ category }: DetailCategoryProps) {

--- a/apps/maeilmail/src/components/questionDetail/DetailCategory.tsx
+++ b/apps/maeilmail/src/components/questionDetail/DetailCategory.tsx
@@ -1,7 +1,8 @@
 import { textWrapper, categoryHighlight } from './questionDetail.css';
+import { QuestionCategoryEN } from '@/common/types/question';
 
 interface DetailCategoryProps {
-  category: 'frontend' | 'backend';
+  category: QuestionCategoryEN;
 }
 
 export default function DetailCategory({ category }: DetailCategoryProps) {

--- a/apps/maeilmail/src/components/questionDetail/apis/getQuestionDetail.ts
+++ b/apps/maeilmail/src/components/questionDetail/apis/getQuestionDetail.ts
@@ -1,7 +1,9 @@
 import mainClient from '@/common/apis/client/mainClient';
 import { API_ROUTES } from '@/common/apis/constants/routes';
+import { QuestionDetail } from '@/common/types/question';
 
 export const getQuestionDetail = async ({ id }: { id: string }) => {
-  const data = await mainClient.get(`${API_ROUTES.question}/${id}`);
+  const data = await mainClient.get<QuestionDetail>(`${API_ROUTES.question}/${id}`);
+
   return data;
 };

--- a/apps/maeilmail/src/components/setting/apis/getMailFrequency.ts
+++ b/apps/maeilmail/src/components/setting/apis/getMailFrequency.ts
@@ -1,8 +1,12 @@
 import mainClient from '@/common/apis/client/mainClient';
 import { pathGenerator } from '@/common/apis/constants/routes';
 
+interface MailFrequency {
+  frequency: 'daily' | 'weekly';
+}
+
 export const getMailFrequency = async (email: string) => {
-  const data = await mainClient.get(pathGenerator.myMailFrequency(email));
+  const data = await mainClient.get<MailFrequency>(pathGenerator.myMailFrequency(email));
 
   return data;
 };

--- a/apps/maeilmail/src/components/setting/apis/getMailFrequency.ts
+++ b/apps/maeilmail/src/components/setting/apis/getMailFrequency.ts
@@ -1,12 +1,13 @@
 import mainClient from '@/common/apis/client/mainClient';
 import { pathGenerator } from '@/common/apis/constants/routes';
+import { MailFrequency } from '@/common/types/mail';
 
-interface MailFrequency {
-  frequency: 'daily' | 'weekly';
+interface GetMailFrequencyResponse {
+  frequency: MailFrequency;
 }
 
 export const getMailFrequency = async (email: string) => {
-  const data = await mainClient.get<MailFrequency>(pathGenerator.myMailFrequency(email));
+  const data = await mainClient.get<GetMailFrequencyResponse>(pathGenerator.myMailFrequency(email));
 
   return data;
 };

--- a/apps/maeilwiki/src/common/store/apis/getMemberProfile.ts
+++ b/apps/maeilwiki/src/common/store/apis/getMemberProfile.ts
@@ -7,8 +7,8 @@ export interface MemberProfile {
   profileImage: string;
 }
 
-export const getMemberProfile = async (): Promise<MemberProfile> => {
-  const data = await mainClient.get(API_ROUTES.memberProfile);
+export const getMemberProfile = async () => {
+  const data = await mainClient.get<MemberProfile>(API_ROUTES.memberProfile);
 
   return data;
 };


### PR DESCRIPTION
### 작업 내용
- server에서 받아오는 response들에 대한 type을 요청 함수마다 작성해주었습니다.
- `mainClient`의 method에 generic으로 선언하였습니다.
- api를 요청하는 함수의 convention을 통일하였습니다.

### 연관 이슈
- close #234 

### 추가 설명
- backend repo의 return과 production server의 network 요청 response를 보고 type을 작성하였습니다.
- 다만, backend repo에는 type의 명시적으로 적혀있지 않은 부분도 있어서 이 부분 한번더 확인해 주시면 좋을 것 같습니다!