### PR TITLE
매일메일 구독 버튼 노출되지 않는 오류 수정

### DIFF
--- a/apps/maeilmail/tsconfig.json
+++ b/apps/maeilmail/tsconfig.json
@@ -4,8 +4,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@maeil/theme": ["../../packages/theme/src"],
-      "@maeil/ui": ["../../packages/ui/src"]
+      "@maeil/theme": ["packages/theme/dist"],
+      "@maeil/ui": ["packages/ui/dist"]
     },
     "plugins": [
       {


### PR DESCRIPTION
### 작업 내용
ui 패키지 변경사항을 매일메일 프로젝트 dev 실행 환경에서 즉시 반영되도록 하기 위해 tsconfig pakcage 경로를 수정했었습니다.
그런데 이로 인해 배포 시 ui 패키지에서 theme 패키지 경로를 정상 인식하지 못하는 문제가 발생했습니다.
따라서 우선 기존과 동일하게 복구합니다.
이후 tsconfig를 prod와 dev로 나누어 관리하는 식으로 문제를 해결해야 할 것 같습니다.

### 연관 이슈

- close #253
